### PR TITLE
Bug fixes and LBFO detection.

### DIFF
--- a/DataCenterBridging.psd1
+++ b/DataCenterBridging.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DataCenterBridging.psm1'
 
 # Version number of this module.
-ModuleVersion = '2021.6.23.36'
+ModuleVersion = '2021.7.14'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Fixed an issue where the script incorrectly exited when an interface was provided and no SET switch was enabled.
- Added LBFO detection.
   - Uses Write-Warning to print the following text to console only when LBFO is in use by the switch or interface passed to the cmdlet.
   ````
   LBFO Teams are not supported. DataCenterBrinding cmdlets may not operate correctly or provide inaccurate results. Microsoft recommends using Switch Embedded Teaming (SET): https://aka.ms/DownWithLBFO
   ````
   - Right now this only throws a warning to screen.
   - Can be used in the future to stop execution.
   - Detection added to Enable-FabricInfo and Get-FabricInfo via a helper function named Test-LbfoEnabled.
   - Test-LbfoEnabled return $true when LBFO is enabled, $false when it is not present.

Sample Usage:

````PowerShell
    # run LBFO testing. Used to throw a warning and nothing else.
    if ($PSBoundParameters.ContainsKey('SwitchName'))
    {
        $null = Test-LbfoEnabled -SwitchName $SwitchName
    }
    elseif ($PSBoundParameters.ContainsKey('InterfaceIndex')) 
    {
        $null = Test-LbfoEnabled -InterfaceIndex $InterfaceIndex
    }
    elseif ($PSBoundParameters.ContainsKey('InterfaceNames')) 
    {
        $null = Test-LbfoEnabled -InterfaceNames $InterfaceNames
    }
````